### PR TITLE
Setup and serve npx repo with error logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Node
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+
+# Build outputs
+build
+coverage
+dist
+.next
+.out
+
+# VCS
+.git
+.gitignore
+
+# Docker
+Dockerfile*
+.dockerignore
+
+# OS/Editor
+.DS_Store
+*.swp
+*.swo
+*.idea
+*.vscode
+
+# App cache
+.cache
+.tmp
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine
+
+# Install required tools: git for cloning, tini for proper signal handling
+RUN apk add --no-cache git tini bash ca-certificates python3 make g++ && update-ca-certificates
+
+ENV NODE_ENV=production \
+    APP_HOME=/app
+
+WORKDIR ${APP_HOME}
+
+# Copy entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Ensure non-root execution (node user exists in node:alpine)
+RUN mkdir -p ${APP_HOME} && chown -R node:node ${APP_HOME}
+USER node
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+
+# Default: no CMD. The entrypoint script performs the clone and starts the server.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
+# MCP Runner Docker Image
+
+A minimal Docker image that, on startup, clones a specified repository and serves its MCP server using `npx` (with sensible fallbacks). Suitable for Docker and Kubernetes.
+
+## Environment Variables
+
+- `NODE_NPX_REPO_URL` (required): Git URL to clone.
+- `NODE_NPX_REPO_TOKEN` (optional/required for private repos): Token used via HTTP headers during clone.
+- `NODE_NPX_REPO_PROXY` (optional): HTTP/HTTPS proxy URL if your cluster requires it.
+- `NODE_NPX_RUN_CMD` (optional): Explicit command to run (e.g. `npx my-mcp@latest`).
+
+## How it works
+
+On container start:
+1. Optionally configures git/npm proxy if `NODE_NPX_REPO_PROXY` is set
+2. Clones `NODE_NPX_REPO_URL` into `/app/repo` (uses `NODE_NPX_REPO_TOKEN` via headers if set)
+3. Installs Node dependencies if `package.json` exists
+4. Selects a start command and `exec`s it so signals are handled properly:
+   - `NODE_NPX_RUN_CMD` (if provided)
+   - `npm run mcp` if present
+   - `npm start` if present
+   - otherwise `npx .` (or `node server.js`/`node .` if no `package.json`)
+
+If the server process exits non-zero, the container exits. Errors are visible in container logs.
+
+## Build
+
+```bash
+docker build -t mcp-runner:latest .
+```
+
+## Run (Docker)
+
+```bash
+docker run --rm \
+  -e NODE_NPX_REPO_URL=https://github.com/your-org/your-mcp-repo.git \
+  -e NODE_NPX_REPO_TOKEN=$YOUR_TOKEN \
+  -e NODE_NPX_REPO_PROXY=http://proxy.internal:3128 \
+  mcp-runner:latest
+```
+
+## Kubernetes Example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-runner
+  template:
+    metadata:
+      labels:
+        app: mcp-runner
+    spec:
+      containers:
+        - name: mcp-runner
+          image: your-registry/mcp-runner:latest
+          env:
+            - name: NODE_NPX_REPO_URL
+              value: "https://github.com/your-org/your-mcp-repo.git"
+            - name: NODE_NPX_REPO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-repo-token
+                  key: token
+            - name: NODE_NPX_REPO_PROXY
+              value: "http://proxy.internal:3128" # optional
+          ports:
+            - containerPort: 3000 # adjust to your MCP server port if needed
+      restartPolicy: Always
+```
+
+Create the secret:
+
+```bash
+kubectl create secret generic mcp-repo-token --from-literal=token=YOUR_TOKEN
+```
+
+## Notes
+
+- Uses `tini` for clean signal handling and `exec`s the server process.
+- Includes `git`, `python3`, `make`, and `g++` to build native modules during `npm install`.
+- Set `NODE_NPX_RUN_CMD` to run a specific command if desired.
+
 # oottb.docker.anymcp.npx
 This docker image will setup and run MCP with npx based

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+log() {
+	printf '[%s] %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*"
+}
+
+err() {
+	printf '[%s] ERROR: %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" >&2
+}
+
+APP_HOME=${APP_HOME:-/app}
+REPO_DIR="$APP_HOME/repo"
+
+REPO_URL=${NODE_NPX_REPO_URL:-}
+REPO_TOKEN=${NODE_NPX_REPO_TOKEN:-}
+REPO_PROXY=${NODE_NPX_REPO_PROXY:-}
+RUN_CMD=${NODE_NPX_RUN_CMD:-}
+
+trap 'err "Startup failed. See logs above for details."' ERR
+
+if [[ -z "$REPO_URL" ]]; then
+	err "NODE_NPX_REPO_URL is required"
+	exit 64
+fi
+
+mkdir -p "$APP_HOME"
+cd "$APP_HOME"
+
+# Configure proxy if provided
+if [[ -n "${REPO_PROXY}" ]]; then
+	log "Configuring proxy for git and npm"
+	export HTTP_PROXY="$REPO_PROXY"
+	export HTTPS_PROXY="$REPO_PROXY"
+	git config --global http.proxy "$REPO_PROXY" || true
+	git config --global https.proxy "$REPO_PROXY" || true
+	npm config set proxy "$REPO_PROXY" >/dev/null 2>&1 || true
+	npm config set https-proxy "$REPO_PROXY" >/dev/null 2>&1 || true
+fi
+
+# Fresh clone on each start
+rm -rf "$REPO_DIR"
+
+log "Cloning repository from provided URL"
+if [[ -n "$REPO_TOKEN" ]]; then
+	# Use Authorization header to avoid leaking token in process list or git remotes
+	git \
+		-c http.extraHeader="Authorization: Bearer ${REPO_TOKEN}" \
+		-c http.extraHeader="PRIVATE-TOKEN: ${REPO_TOKEN}" \
+		clone --depth 1 "$REPO_URL" "$REPO_DIR"
+else
+	git clone --depth 1 "$REPO_URL" "$REPO_DIR"
+fi
+
+cd "$REPO_DIR"
+log "Clone complete at $(pwd)"
+
+if [[ -f package.json ]]; then
+	log "Installing Node dependencies"
+	if [[ -f package-lock.json ]]; then
+		npm ci
+	else
+		npm install
+	fi
+else
+	log "No package.json found; proceeding without npm install"
+fi
+
+start_server() {
+	# Allow user to override run command
+	if [[ -n "$RUN_CMD" ]]; then
+		log "Starting server using custom command"
+		exec bash -lc "$RUN_CMD"
+	fi
+
+	# Prefer predictable scripts; default to npx .
+	if [[ -f package.json ]]; then
+		# npm run mcp
+		if node -e "const p=require('./package.json'); process.exit(p.scripts&&p.scripts.mcp?0:1)" 2>/dev/null; then
+			log "Running: npm run mcp"
+			exec npm run mcp
+		fi
+
+		# npm start
+		if node -e "const p=require('./package.json'); process.exit(p.scripts&&p.scripts.start?0:1)" 2>/dev/null; then
+			log "Running: npm start"
+			exec npm start
+		fi
+
+		# Fall back to npx .
+		log "Running: npx ."
+		exec npx --yes --prefer-online --quiet .
+	fi
+
+	# Try common Node entrypoints when no package.json
+	if [[ -f server.js ]]; then
+		log "Running: node server.js"
+		exec node server.js
+	fi
+
+	log "Running: node ."
+	exec node .
+}
+
+log "Starting MCP server"
+start_server
+


### PR DESCRIPTION
Add a Docker image that clones a specified Git repository and serves its MCP application, configurable via environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe480caa-cb94-499b-951f-fa0ad3a0779f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe480caa-cb94-499b-951f-fa0ad3a0779f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

